### PR TITLE
Upgraded findbugs-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
                 <jdk>[1.8,)</jdk>
             </activation>
             <properties>
-                <findbugs.plugin.version>3.0.0</findbugs.plugin.version>
+                <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Builds failed with old version when using Maven 3.6.0

Signed-off-by: Egor Margineanu <egor.margineanu@gmail.com>